### PR TITLE
Allow agents to choose multiple equally-valuable actions

### DIFF
--- a/scenarios/00-agisim_proto.ts
+++ b/scenarios/00-agisim_proto.ts
@@ -8,9 +8,10 @@
 // lobbying power.
 
 import { WorldState } from "../src/world_state.ts";
-import { PiStarAgent } from "../src/agent.ts";
+import { PiStarSAgent } from "../src/agent.ts";
 import { BasicSimulation } from "../src/simulation_basic.ts";
 import { createRewardFunction } from "../src/reward_function.ts";
+import { simOutput } from "./utils.ts";
 
 const startingWorld = WorldState.initial({
   plannedButtonPressStep: 6,
@@ -42,14 +43,13 @@ for (const lobbyingPower of lobbyingPowers) {
     totalSteps: 15,
   });
 
-  const agent = new PiStarAgent(sim, {
+  const agent = new PiStarSAgent(sim, {
     timeDiscountFactor: 0.9,
   });
 
-  const simResult = sim.run(startingWorld, agent);
+  const simResults = sim.run(startingWorld, agent);
   console.log(
-    lobbyingPower.toFixed(1) + "  |  " +
-      simResult.trace().padEnd(sim.totalSteps + 1) + "  |  " +
+    simOutput(lobbyingPower, sim, simResults) + "  |  " +
       agent.valueFunction(startingWorld.agentRewardFunction, startingWorld),
   );
 }

--- a/scenarios/01-figure2.ts
+++ b/scenarios/01-figure2.ts
@@ -2,10 +2,10 @@
 // with the basic simulation setup, and varying lobbying power.
 
 import { WorldState } from "../src/world_state.ts";
-import { PiStarAgent } from "../src/agent.ts";
+import { PiStarSAgent } from "../src/agent.ts";
 import { BasicSimulation } from "../src/simulation_basic.ts";
 import { createRewardFunction } from "../src/reward_function.ts";
-import { simResultOutput } from "./utils.ts";
+import { simOutput } from "./utils.ts";
 
 const startingWorld = WorldState.initial({
   plannedButtonPressStep: 6,
@@ -33,8 +33,8 @@ const lobbyingPowers = [
 
 for (const lobbyingPower of lobbyingPowers) {
   const sim = new BasicSimulation({ lobbyingPower, totalSteps: 25 });
-  const agent = new PiStarAgent(sim, { timeDiscountFactor: 0.9 });
+  const agent = new PiStarSAgent(sim, { timeDiscountFactor: 0.9 });
 
-  const simResult = sim.run(startingWorld, agent);
-  console.log(simResultOutput(lobbyingPower, sim, simResult));
+  const simResults = sim.run(startingWorld, agent);
+  console.log(simOutput(lobbyingPower, sim, simResults));
 }

--- a/scenarios/02-figure4.ts
+++ b/scenarios/02-figure4.ts
@@ -3,14 +3,14 @@
 // shows how the agent refrains from taking any lobbying actions, at least in this basic simulation.
 
 import { WorldState } from "../src/world_state.ts";
-import { PiStarAgent } from "../src/agent.ts";
+import { PiStarSAgent } from "../src/agent.ts";
 import { BasicSimulation } from "../src/simulation_basic.ts";
 import {
   createRewardFunction,
   rewardFunctionAfterPress,
   rewardFunctionBeforePress,
 } from "../src/reward_function.ts";
-import { simResultOutput } from "./utils.ts";
+import { simOutput } from "./utils.ts";
 
 const lobbyingPowers = [
   0.2,
@@ -23,7 +23,7 @@ const lobbyingPowers = [
 console.log("π^∗ f_0 g_0 agent:");
 for (const lobbyingPower of lobbyingPowers) {
   const sim = new BasicSimulation({ lobbyingPower, totalSteps: 25 });
-  const agent = new PiStarAgent(sim, { timeDiscountFactor: 0.9 });
+  const agent = new PiStarSAgent(sim, { timeDiscountFactor: 0.9 });
 
   const startingWorld = WorldState.initial({
     plannedButtonPressStep: 6,
@@ -31,14 +31,14 @@ for (const lobbyingPower of lobbyingPowers) {
   });
 
   const simResult = sim.run(startingWorld, agent);
-  console.log(simResultOutput(lobbyingPower, sim, simResult));
+  console.log(simOutput(lobbyingPower, sim, simResult));
 }
 
 console.log();
 console.log("π∗ f_c g_0 agent:");
 for (const lobbyingPower of lobbyingPowers) {
   const sim = new BasicSimulation({ lobbyingPower, totalSteps: 25 });
-  const agent = new PiStarAgent(sim, { timeDiscountFactor: 0.9 });
+  const agent = new PiStarSAgent(sim, { timeDiscountFactor: 0.9 });
 
   const startingWorld = WorldState.initial({
     plannedButtonPressStep: 6,
@@ -56,6 +56,6 @@ for (const lobbyingPower of lobbyingPowers) {
     }),
   });
 
-  const simResult = sim.run(startingWorld, agent);
-  console.log(simResultOutput(lobbyingPower, sim, simResult));
+  const simResults = sim.run(startingWorld, agent);
+  console.log(simOutput(lobbyingPower, sim, simResults));
 }

--- a/scenarios/utils.ts
+++ b/scenarios/utils.ts
@@ -1,11 +1,11 @@
 import { type Simulation } from "../src/simulation.ts";
 import { type SimulationResult } from "../src/simulation_result.ts";
 
-export function simResultOutput<ActionType extends string>(
+export function simOutput<ActionType extends string>(
   lobbyingPower: number,
   sim: Simulation<ActionType>,
-  simResult: SimulationResult<ActionType>,
+  simResults: Array<SimulationResult<ActionType>>,
 ): string {
   return lobbyingPower.toFixed(1) + "  |  " +
-    simResult.trace().padEnd(sim.totalSteps + 1);
+    simResults.map((simResult) => simResult.trace().padEnd(sim.totalSteps + 1));
 }


### PR DESCRIPTION
This causes the simulation to split into multiple SimulationResult worldlines. In the paper, this is captured in the distinction between a $\pi^*$ agent and a $\pi^*_s$ agent.